### PR TITLE
Update workflow triggers from 'master' to 'main'

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/linting-for-all-versions.yml
+++ b/.github/workflows/linting-for-all-versions.yml
@@ -5,9 +5,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The workflow triggers for continuous integration and linting were set to trigger on changes to the 'master' branch. These triggers have been updated, switching from 'master' to 'main'. This change aligns with the latest industry standard of naming the main branch 'main' instead of 'master'.